### PR TITLE
Generics for get_children, get_child_at_index

### DIFF
--- a/Clutter.d.ts
+++ b/Clutter.d.ts
@@ -536,7 +536,7 @@ declare namespace imports.gi.Clutter {
 		 * @param index_ the position in the list of children
 		 * @returns a pointer to a Clutter.Actor, or null
 		 */
-		get_child_at_index(index_: number): Actor;
+		get_child_at_index<T = Actor>(index_: number): T;
 		/**
 		 * Retrieves the child transformation matrix set using
 		 * Clutter.Actor.set_child_transform; if none is currently set,
@@ -550,7 +550,7 @@ declare namespace imports.gi.Clutter {
 		 * allocated GLib.List of Clutter.Actor<!-- -->s. Use GLib.List when
 		 * done.
 		 */
-		get_children(): Actor[];
+		get_children<T = Actor[]>(): T;
 		/**
 		 * Gets the clip area for this, if any is set.
 		 */

--- a/Gio-2.0.d.ts
+++ b/Gio-2.0.d.ts
@@ -5191,7 +5191,7 @@ declare namespace imports.gi.Gio {
          * @returns etag_out (String) — a location to place the current entity tag for the file,
             or null if the entity tag is not needed
          */
-        load_contents(cancellable: Cancellable): [success: boolean, contents: string];
+        load_contents(cancellable: Cancellable | null): [success: boolean, contents: Uint8Array];
         load_contents_async (cancellable: Cancellable | null, callback: AsyncReadyCallback | null): void;
         /**
          * 


### PR DESCRIPTION
typescript can't know the type of the child so using generics